### PR TITLE
Fix index-state syntax

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,6 +16,8 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
+-- repeat hackage index state to work around haskell.nix parsing limitation
+index-state: 2022-10-24T00:00:00Z
 index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2022-10-24T00:00:00Z

--- a/cabal.project
+++ b/cabal.project
@@ -16,8 +16,11 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
--- Bump this if you need newer packages from CHaP
-index-state: cardano-haskell-packages 2022-11-01T00:00:00Z
+index-state:
+  -- Bump this if you need newer packages from Hackage
+  , hackage.haskell.org 2022-10-24T00:00:00Z
+  -- Bump this if you need newer packages from CHaP
+  , cardano-haskell-packages 2022-11-01T00:00:00Z
 
 -- Plutarch
 --


### PR DESCRIPTION
The second index-state stanza completely ovverides the first, resetting hackage index state to HEAD. See haskell/cabal#8568